### PR TITLE
The even/odd page margins must have the same value

### DIFF
--- a/templates/latex/begin.ftl
+++ b/templates/latex/begin.ftl
@@ -51,7 +51,7 @@
 
 %%%%%%%PAGE SETUP%%%%%%%%%%%%%
 \oddsidemargin     -6mm
-\evensidemargin   -19mm
+\evensidemargin    -6mm
 \textwidth        180mm
 \topmargin        -10mm
 \textheight       250mm


### PR DESCRIPTION
The even/odd page margins have different values which makes pdf layout weird. 

You can see the issue looking at this screenshot:
![screen shot 2013-08-23 at 3 21 01 pm](https://f.cloud.github.com/assets/133986/1018945/c4d59c48-0c35-11e3-9795-60cd5af2ef07.png)
