### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ Changelog
 * August 07, 2012 A lot of bugs fixed and new features added since last update of this changelog, here are some of them:
     * it's possible to define boolean variables (in a similar way as C ifdef) to be avaiable at ftl templates with the option -e \<var1\> \<var2\>...
     * new output option (-kindle) added to generate html output focused on building ebooks such as .epub or .mobi formats.
-    * a book may be splitted in multiple parts simply by adding [part \<title\>] tag at the beggining of a chapter.
+    * a book may be splitted in multiple parts simply by adding [part \<title\>] tag at the beginning of a chapter.
     * a new tag to render code published at [gist](https://gist.github.com/): [gist \<gist-id\>]
 * September 15, 2011 Dropped support for one section per page, HTML. Instead, the -html option will generate an experimental one-page textbook (in which we're working :) ).
 * April 28, 2011 Support to syntax highlighting using Pygments (in many many languages).


### PR DESCRIPTION
@caelum, I've corrected a typographical error in the documentation of the [tubaina](https://github.com/caelum/tubaina) project. Specifically, I've changed beggining to beginning. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
